### PR TITLE
Fix support for plain text content in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2024-08-29
+### Changed
+- N/A
+
+### Fixed
+- A bug (in [#5](https://github.com/samgaudet/mkdocs-madlibs/issues/5)) where plain text content is not properly parsed and templated by `mkdocs-madlibs`.
+
 ## [1.0.0] - 2024-08-22
 ### Changed
 - Initial release for the package, including core custom fence functionality.

--- a/mkdocs_madlibs/__init__.py
+++ b/mkdocs_madlibs/__init__.py
@@ -1,5 +1,5 @@
 """mkdocs-madlibs Code templating with user inputs for MkDocs superfences."""
 from mkdocs_madlibs._fence import fence
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __all__ = ["fence"]


### PR DESCRIPTION
# Overview

This PR adds a fix for plain text content as reported in https://github.com/samgaudet/mkdocs-madlibs/issues/5.

# Testing/example

The changes in this PR were tested with the following test cases:

````md
```madlibs
bash
~~~
gcloud config set project ___PROJECT_ID___
```

```madlibs
bash
~~~
export A=B
___COMMAND___ --help
```
````