### PR TITLE
Add SVG icon to plain text code snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2] - 2024-08-30
+### Changed
+- N/A
+
+### Fixed
+- A bug missed (in [#5](https://github.com/samgaudet/mkdocs-madlibs/issues/5) and [#7](https://github.com/samgaudet/mkdocs-madlibs/issues/7)) where the SVG pen icon is not added to plain text code snippets.
+
 ## [1.1.1] - 2024-08-29
 ### Changed
 - Updated documentation.

--- a/mkdocs_madlibs/__init__.py
+++ b/mkdocs_madlibs/__init__.py
@@ -1,5 +1,5 @@
 """mkdocs-madlibs Code templating with user inputs for MkDocs superfences."""
 from mkdocs_madlibs._fence import fence
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __all__ = ["fence"]

--- a/mkdocs_madlibs/_fence.py
+++ b/mkdocs_madlibs/_fence.py
@@ -26,11 +26,11 @@ def prepare_madlibs_element(
     - Set `spellcheck` to `false` to avoid visual bugs with spelling errors.
 
     Args:
-        element (PageElement):
-        substring (str):
+        element (PageElement): The element to update to an editable content.
+        substring (str): The input name / placeholder input.
 
     Returns:
-        The updated PageElement to be added to a Soup.
+        The updated PageElement to be added to a BeautifulSoup.
     """
     element.string = substring.replace(TRIPLE_UNDERSCORE, "")
     element["title"] = f"Edit {substring.replace(TRIPLE_UNDERSCORE, '')}"
@@ -46,6 +46,35 @@ def prepare_madlibs_element(
     # https://stackoverflow.com/a/3805897
     element["onClick"] = "document.execCommand('selectAll',false,null)"
     element["spellcheck"] = "false"
+
+    return element
+
+
+def add_pen_svg_to_madlibs_element(
+    soup: BeautifulSoup,
+    element: PageElement,
+) -> PageElement:
+    """Adds a pen icon as an SVG Tag to the madlibs HTML content.
+
+    Args:
+        soup (BeautifulSoup): The HTML parsed soup to add the new Tags to.
+        element (PageElement): The element to add an icon to.
+
+    Returns:
+        The updated PageElement to be added to a BeautifulSoup.
+    """
+    svg = soup.new_tag(
+        name="svg",
+        xmlns="http://www.w3.org/2000/svg",
+        viewBox="0 0 512 512",
+        **{"class": MADLIBS_EDITABLE_ICON_CLASS},
+    )
+    svg_path = soup.new_tag(
+        name="path",
+        d=SVG_PATH,
+    )
+    svg.append(svg_path)
+    element.append(svg)
 
     return element
 
@@ -75,6 +104,7 @@ def modify_code_block_html(html: str) -> str:
                 if substring and substring.startswith(TRIPLE_UNDERSCORE):
                     new_span = soup.new_tag("span")
                     new_span = prepare_madlibs_element(new_span, substring)
+                    new_span = add_pen_svg_to_madlibs_element(soup, new_span)
                     element.insert_after(new_span)
                 elif substring:
                     new_element = NavigableString(substring)
@@ -101,18 +131,9 @@ def modify_code_block_html(html: str) -> str:
                     duplicated_span = prepare_madlibs_element(
                         duplicated_span, substring
                     )
-                    svg = soup.new_tag(
-                        name="svg",
-                        xmlns="http://www.w3.org/2000/svg",
-                        viewBox="0 0 512 512",
-                        **{"class": MADLIBS_EDITABLE_ICON_CLASS},
+                    duplicated_span = add_pen_svg_to_madlibs_element(
+                        soup, duplicated_span
                     )
-                    svg_path = soup.new_tag(
-                        name="path",
-                        d=SVG_PATH,
-                    )
-                    svg.append(svg_path)
-                    duplicated_span.append(svg)
                 else:
                     duplicated_span.string = substring
 


### PR DESCRIPTION
# Overview

This PR adds a fix previously applied to highlighted code snippets to include a pen icon as an SVG HTML Tag (instead of a `background-image` in CSS).

# Testing/example

Previously, code snippets without syntax highlighting, such as the following, would be missing the pen icon to indicate they are editable:

````md
```madlibs
text
~~~
This is a ___NOUN___.
```
````