### PR TITLE
Add support for titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -23,7 +23,8 @@ body:
       label: Version
       description: What version of `mkdocs-madlibs` are you running?
       options:
-        - 1.2.0 (Default)
+        - 1.2.1 (Default)
+        - 1.2.0
         - 1.1.2
         - 1.1.1
         - 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2024-09-20
+### Changed
+- A new feature (in [#22](https://github.com/samgaudet/mkdocs-madlibs/issues/22)) is added to support code block titles.
+
+### Fixed
+- N/A
+
 ## [1.2.0] - 2024-09-04
 ### Changed
 - A new feature is added to allow escaping Mad Libs editable content via triple-carets (^^^) in addition to triple-underscores.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -86,3 +86,28 @@ text
 ~~~
 hello_my_name_is_^^^NAME^^^
 ```
+
+### Adding a title
+
+MkDocs Mad Libs supports [adding titles](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-a-title).
+However, attributes are only passed to the MkDocs Mad Libs formatter if an attribute style header is used.
+In order to use an attribute style header, you must first enable the
+[_Attribute Lists_ extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists).
+
+The following fenced code:
+
+````md
+```{.madlibs title="Hello world example"}
+python
+~~~
+print("Hello, ___NAME___.")
+```
+````
+
+Renders this interactive code block when using `mkdocs-madlibs`:
+
+```{.madlibs title="Hello world example"}
+python
+~~~
+print("Hello, ___NAME___.")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ plugins:
       enable_creation_date: true
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span

--- a/mkdocs_madlibs/__init__.py
+++ b/mkdocs_madlibs/__init__.py
@@ -2,5 +2,5 @@
 
 from mkdocs_madlibs._fence import fence
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __all__ = ["fence"]

--- a/mkdocs_madlibs/_fence.py
+++ b/mkdocs_madlibs/_fence.py
@@ -181,12 +181,15 @@ def fence(
 
     _language = parsed_source[0].strip()
     _source = parsed_source[1].strip()
+    _title = attrs.get("title", None) if attrs else None
 
     highlighter = Highlight()
+
     code_block = highlighter.highlight(
         src=_source,
         language=_language,
         classes=[f"language-{_language}.highlight"],
+        title=_title,
     )
 
     modified_html = modify_code_block_html(code_block)

--- a/tests/unit/test_fence.py
+++ b/tests/unit/test_fence.py
@@ -91,3 +91,23 @@ def test_fence(test_markdown: str, test_html: str):
     generated_html.body.append(BeautifulSoup(html, "html.parser"))  # type: ignore
 
     assert expected_html.prettify() == generated_html.prettify()
+
+
+def test_fence__with_title_attr():
+    """Test the fence functionality with a title attribute specified."""
+    TEST_TITLE = "This is a test title"
+
+    html = fence(
+        source=BASIC_CODE_BLOCK_MARKDOWN__UNDERSCORES,
+        language=None,
+        css_class=None,
+        options=None,
+        md=None,
+        attrs={"title": TEST_TITLE},
+    )
+
+    generated_html = BeautifulSoup(BASIC_HTML_DOCUMENT, "html.parser")
+    generated_html.body.append(BeautifulSoup(html, "html.parser"))  # type: ignore
+
+    title_divs = generated_html.find_all(name="span", attrs={"class": "filename"})
+    assert title_divs[0].text.strip() == TEST_TITLE


### PR DESCRIPTION
# Description
This PR adds support for _titles_ as is natively supported in code blocks for `mkdocs-material`.

# Testing
A new unit test is added to the test suite and an example of this functionality is added to the package documentation.

# Pre-deploy checklist
<!-- if you are preparing a new release, please ensure you have done the following -->

- [x] Updated the `__version__` number in `__init__.py`
- [x] Added an entry to the `CHANGELOG.md`
- [x] Updated the default version in the bug report form (`.github/ISSUE_TEMPLATE/bug-form.yml`)
