### PR TITLE
Add support for hl_lines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-form.yml
+++ b/.github/ISSUE_TEMPLATE/bug-form.yml
@@ -23,7 +23,8 @@ body:
       label: Version
       description: What version of `mkdocs-madlibs` are you running?
       options:
-        - 1.2.1 (Default)
+        - 1.2.2 (Default)
+        - 1.2.1
         - 1.2.0
         - 1.1.2
         - 1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2024-10-01
+### Changed
+- A new feature is added to support code block line highlighting.
+
+### Fixed
+- N/A
+
 ## [1.2.1] - 2024-09-20
 ### Changed
 - A new feature (in [#22](https://github.com/samgaudet/mkdocs-madlibs/issues/22)) is added to support code block titles.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,3 +111,36 @@ python
 ~~~
 print("Hello, ___NAME___.")
 ```
+
+### Highlighting specific lines
+
+MkDocs Mad Libs supports [highlighting specific lines](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#highlighting-specific-lines).
+However, attributes are only passed to the MkDocs Mad Libs formatter if an attribute style header is used.
+In order to use an attribute style header, you must first enable the
+[_Attribute Lists_ extension](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/#attribute-lists).
+
+The following fenced code:
+
+````md
+```{.madlibs hl_lines="1-2 5"}
+python
+~~~
+def greet(name: str) -> None:
+    print(f"Hello, {name}.")
+
+if __name__ == "__main__":
+    greet("___NAME___")
+```
+````
+
+Renders this interactive code block when using `mkdocs-madlibs`:
+
+```{.madlibs hl_lines="1-2 5"}
+python
+~~~
+def greet(name: str) -> None:
+    print(f"Hello, {name}.")
+
+if __name__ == "__main__":
+    greet("___NAME___")
+```

--- a/mkdocs_madlibs/__init__.py
+++ b/mkdocs_madlibs/__init__.py
@@ -2,5 +2,5 @@
 
 from mkdocs_madlibs._fence import fence
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __all__ = ["fence"]

--- a/tests/unit/test_fence.py
+++ b/tests/unit/test_fence.py
@@ -111,3 +111,23 @@ def test_fence__with_title_attr():
 
     title_divs = generated_html.find_all(name="span", attrs={"class": "filename"})
     assert title_divs[0].text.strip() == TEST_TITLE
+
+
+def test_fence__with_hl_lines_attr():
+    """Test the fence functionality with line highlighting attributes specified."""
+    HL_LINES = "1 3-5"
+
+    html = fence(
+        source=MULTI_INPUT_CODE_BLOCK_MARKDOWN,
+        language=None,
+        css_class=None,
+        options=None,
+        md=None,
+        attrs={"hl_lines": HL_LINES},
+    )
+
+    generated_html = BeautifulSoup(BASIC_HTML_DOCUMENT, "html.parser")
+    generated_html.body.append(BeautifulSoup(html, "html.parser"))  # type: ignore
+
+    title_divs = generated_html.find_all(name="span", attrs={"class": "hll"})
+    assert len(title_divs) == 4


### PR DESCRIPTION
# Description
<!-- please include a summary of your changes -->
This PR adds support for the code block attribute `hl_lines`, as is natively supported in `superfences`: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#highlighting-specific-lines.

# Testing
<!-- please include details of how your changes have been tested -->
A new unit test case is added.

# Pre-deploy checklist
<!-- if you are preparing a new release, please ensure you have done the following -->

- [x] Updated the `__version__` number in `__init__.py`
- [x] Added an entry to the `CHANGELOG.md`
- [x] Updated the default version in the bug report form (`.github/ISSUE_TEMPLATE/bug-form.yml`)
